### PR TITLE
Fixes #629 - Results don't wrap

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -590,6 +590,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
   const _renderRow = (rowData = {}) => {
     return (
       <ScrollView
+        contentContainerStyle={{ flex: 1 }}
         scrollEnabled={props.isRowScrollable}
         keyboardShouldPersistTaps={props.keyboardShouldPersistTaps}
         horizontal={true}
@@ -598,7 +599,9 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
       >
         <TouchableHighlight
           // eslint-disable-next-line react-native/no-inline-styles
-          style={{ minWidth: '100%' }}
+          style={
+            props.isRowScrollable ? { minWidth: "100%" } : { width: "100%" }
+          }
           onPress={() => _onPress(rowData)}
           underlayColor={props.listUnderlayColor || '#c8c7cc'}
         >


### PR DESCRIPTION
A proposed solution to the issue in #629 where result text is cut off when isRowScrollabe={false}